### PR TITLE
Convex Hull improvements

### DIFF
--- a/src/man/vision/Threshold.cpp
+++ b/src/man/vision/Threshold.cpp
@@ -275,23 +275,26 @@ void Threshold::runs() {
 
 void Threshold::findGoals(int column, int topEdge) {
     const int BADSIZE = 10;
-	const int GAP = 25;
+	const int GAP = 15;
     // scan up for goals
     int bad = 0, blues = 0, yellows = 0, pinks = 0;
     int firstBlue = topEdge, firstYellow = topEdge, lastBlue = topEdge,
         lastYellow = topEdge, firstPink = topEdge, lastPink = topEdge;
     topEdge = min(topEdge, lowerBound[column]);
     int robots = 0;
+	int blueRun = 0;
     for (int j = topEdge; bad < BADSIZE && j >= 0; j--) {
         // get the next pixel
         unsigned char pixel = getThresholded(j,column);
         if (Utility::isBlue(pixel)) {
-            lastBlue = j;
-            blues++;
-            bad--;
-            if (firstBlue == topEdge) {
-                firstBlue = j;
-            }
+			if (j - lastBlue < 4) {
+				lastBlue = j;
+				blues++;
+				bad--;
+				if (firstBlue == topEdge) {
+					firstBlue = j;
+				}
+			}
         }
         if (Utility::isYellow(pixel)) {
             lastYellow = j;
@@ -320,18 +323,24 @@ void Threshold::findGoals(int column, int topEdge) {
     }
     // now do the same going down from the horizon
     bad = 0;
+	blueRun = 0;
+	int greens = 0;
     for (int j = topEdge + 1; bad < BADSIZE && j < lowerBound[column]; j++) {
         // note:  These were thresholded in the findBallsCrosses loop
         unsigned char pixel = getThresholded(j,column);
         bool found = false;
-        if (Utility::isBlue(pixel)) {
-            firstBlue = j;
-            blues++;
+        if (Utility::isBlue(pixel) && !Utility::isGreen(pixel)) {
+            //blues++;
+			//blueRun++;
+			if (blueRun > 3 && greens < 4) {
+				firstBlue = j;
+			}
             found = true;
         }
         if (Utility::isYellow(pixel)) {
             firstYellow = j;
             yellows++;
+			blueRun = 0;
             found = true;
         }
         if (Utility::isNavy(pixel) || Utility::isRed(pixel)) {
@@ -340,9 +349,12 @@ void Threshold::findGoals(int column, int topEdge) {
         }
         if (Utility::isGreen(pixel)) {
             bad++;
+			blueRun = 0;
+			greens++;
         }
         if (!found) {
             bad++;
+			blueRun = 0;
         }
     }
     if (blues > 10) {


### PR DESCRIPTION
Fixes some long standing problems with our convex hull calculations.  These mainly affect how items that block parts of the field (robots, the ball) impact our convex hull.  Also, we now scan for "spikes" in our hull caused by stray patches of green.  These mainly happen on blue goals and on black items (like the heaters in 223).  The improved hulls mean a) we'll see more stuff (goals, robots, balls) and b) we'll see less stuff (false blue goals).
