### PR TITLE
Fixed likely memory leak in Comm.

### DIFF
--- a/src/man/comm/Comm.h
+++ b/src/man/comm/Comm.h
@@ -46,7 +46,7 @@ public:
 
     int getTOOLState();
     std::string getRobotName();
-    std::list<std::vector<float> >* latestComm();
+    std::list<std::vector<float> > latestComm();
     TeammateBallMeasurement getTeammateBallReport();
     void setData(std::vector<float> &data);
 
@@ -78,7 +78,7 @@ private:
     // Sending packet data
     std::vector<float> data;
     // Received data
-    std::list<std::vector<float> >* latest;
+    std::list<std::vector<float> > latest;
 
     // References to global data structures
     boost::shared_ptr<Sensors> sensors; // thread-safe access to sensors

--- a/src/man/noggin/Noggin.cpp
+++ b/src/man/noggin/Noggin.cpp
@@ -385,6 +385,7 @@ void Noggin::updateLocalization()
         RangeBearingMeasurement k(vision->ball);
         m = k;
     } else {
+
         // If it's off for more then the threshold, then try and use mate data
         TeammateBallMeasurement n;
 #       ifdef USE_TEAMMATE_BALL_REPORTS
@@ -392,13 +393,16 @@ void Noggin::updateLocalization()
         if (!(n.ballX == 0.0 && n.ballY == 0.0) &&
             !(gc->gameState() == STATE_INITIAL ||
               gc->gameState() == STATE_FINISHED)) {
+
             m.distance = hypotf(loc->getXEst() - n.ballX,
                                loc->getYEst() - n.ballY);
             m.bearing = subPIAngle(atan2(n.ballY - loc->getYEst(),
                                          n.ballX - loc->getXEst()) -
                                    loc->getHEst());
+
             m.distanceSD = vision->ball->ballDistanceToSD(m.distance);
             m.bearingSD =  vision->ball->ballBearingToSD(m.bearing);
+
 #           ifdef DEBUG_TEAMMATE_BALL_OBSERVATIONS
             cout << setprecision(4)
                  << "Using teammate ball report of (" << m.distance << ", "
@@ -406,6 +410,7 @@ void Noggin::updateLocalization()
                  << "(" << n.ballX << ", " << n.ballY << ")" << endl;
             cout << *ballEKF << endl;
 #           endif
+
         }
 #       endif
     }


### PR DESCRIPTION
We were passing along a list pointer but never deleting the original list. Changed it to use an explicit object (maybe a bit slower, but worth the memory safety).
