### PR TITLE
fixed the roboimageviewer showing the image as dark some of the time - th

### DIFF
--- a/src/qtool/viewer/LogViewer.cpp
+++ b/src/qtool/viewer/LogViewer.cpp
@@ -46,10 +46,12 @@ using namespace man::memory;
 
     void LogViewer::nextImage() {
         dataManager->getNext();
+        roboImageViewer->repaint();
     }
 
     void LogViewer::prevImage() {
         dataManager->getPrev();
+        roboImageViewer->repaint();
     }
 
 }


### PR DESCRIPTION
fixed the roboimageviewer showing the image as dark some of the time - the bitmap type was never getting initialized, now it's getting initialized to Color
