### PR TITLE
fixed cmake first looking in the system folders and then the ext folder when looking for packages

### DIFF
--- a/src/man/cmake/generic.cmake
+++ b/src/man/cmake/generic.cmake
@@ -33,12 +33,14 @@ SET( CMAKE_USE_PYTHON_VERSION 2.6 )
 ########################## FIND PATH
 # we should look in the naoqi sdk folder for the libraries we need first
 # so we use the same version as on the robot
-SET( CMAKE_FIND_ROOT_PATH  $ENV{NBITES_DIR}/ext/ )
+# The order matters - this forces cmake to first look in
+# nbites_dir/ext, then the regular system folders
+SET( CMAKE_FIND_ROOT_PATH  $ENV{NBITES_DIR}/ext/ /usr/ /)
 
 # search for programs in the system root
-SET( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH )
+SET( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY )
 # for libraries and headers in the nao sdk preferably, if not defaults to
 # system root
-SET( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH )
-SET( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH )
-SET( CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH )
+SET( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+SET( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+SET( CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY )


### PR DESCRIPTION
fixed cmake first looking in the system folders and then the ext folder when looking for packages
