### PR TITLE
Color Calibration improvements

### DIFF
--- a/src/qtool/QTool.cpp
+++ b/src/qtool/QTool.cpp
@@ -16,7 +16,7 @@ using overseer::OverseerClient;
 
 QTool::QTool() : EmptyQTool("QTOOL"),
                  dataLoader(new DataLoader(dataManager)),
-                 colorCalibrate(new ColorCalibrate(dataManager)),
+                 colorCalibrate(new ColorCalibrate(dataManager, this)),
                  colorTableCreator(new ColorTableCreator(dataManager)),
                  memoryViewer(new MemoryViewer(dataManager)),
                  visionViewer(new VisionViewer(dataManager)),

--- a/src/qtool/colorcreator/ColorCalibrate.cpp
+++ b/src/qtool/colorcreator/ColorCalibrate.cpp
@@ -5,6 +5,7 @@
 
 #include <QFileDialog>
 #include <QCheckBox>
+#include <QMouseEvent>
 
 namespace qtool {
 namespace colorcreator {
@@ -13,6 +14,8 @@ using namespace qtool::data;
 using namespace qtool::image;
 using namespace man::corpus;
 using namespace man::memory;
+
+#define BOX 5
 
 ColorCalibrate::ColorCalibrate(DataManager::ptr dataManager, QWidget *parent) :
         QWidget(parent), dataManager(dataManager), imageTabs(new QTabWidget(this)),
@@ -39,15 +42,21 @@ ColorCalibrate::ColorCalibrate(DataManager::ptr dataManager, QWidget *parent) :
     }
     leftLayout->addWidget(imageTabs);
 
-    //update the threshold when the underlying image changes
-    dataManager->connectSlot(this, SLOT(updateThresholdedImage()), "MRawImages");
-    dataManager->connectSlot(this, SLOT(updateThresholdedImage()), "MRawImages");
+    QObject::connect(&topChannelImage, SIGNAL(mouseClicked(int, int, int, bool)),
+                     this, SLOT(canvassClicked(int, int, int, bool)));
+    QObject::connect(&bottomChannelImage, SIGNAL(mouseClicked(int, int, int, bool)),
+                     this, SLOT(canvassClicked(int, int, int, bool)));
+
 
     imageTabs->addTab(&topChannelImage, "Top Image");
     dataManager->connectSlot(&topChannelImage, SLOT(updateView()), "MRawImages");
 
     imageTabs->addTab(&bottomChannelImage, "Bottom Image");
     dataManager->connectSlot(&bottomChannelImage, SLOT(updateView()), "MRawImages");
+
+    //update the threshold when the underlying image changes
+    dataManager->connectSlot(this, SLOT(updateThresholdedImage()), "MRawImages");
+    dataManager->connectSlot(this, SLOT(updateThresholdedImage()), "MRawImages");
 
     connect(imageTabs, SIGNAL(currentChanged(int)), this, SLOT(imageTabSwitched(int)));
 
@@ -89,6 +98,9 @@ ColorCalibrate::ColorCalibrate(DataManager::ptr dataManager, QWidget *parent) :
     mainLayout->addLayout(rightLayout);
 
     this->setLayout(mainLayout);
+
+	lastClickedX = -BOX;
+	lastClickedY = -BOX;
 }
 
 // flip between one and all colors
@@ -96,6 +108,42 @@ ColorCalibrate::ColorCalibrate(DataManager::ptr dataManager, QWidget *parent) :
 		displayAllColors = !displayAllColors;
 		updateThresholdedImage();
 	}
+
+void ColorCalibrate::canvassClicked(int x, int y, int brushSize, bool leftClick) {
+	std::cout << "Clicked " << x << " " << y << " " << std::endl;
+    BMPYUVImage* image;
+
+    if (currentImage == Camera::TOP) {
+        image = topImage;
+    } else {
+        image = bottomImage;
+    }
+
+	byte yi = image->getYUVImage()->getY(x, y);
+	byte u = image->getYUVImage()->getU(x, y);
+	byte v = image->getYUVImage()->getV(x, y);
+
+	std::cout << "YUV " << (int)yi << " " << (int)u << " " <<
+		(int)v << std::endl;
+
+	Color color;
+	color.setYuv(yi, u, v);
+	std::cout << "HSZ " << color.getH() << " " << color.getS() <<
+		" " << color.getZ() << std::endl;
+
+	currentColorSpace->verboseContains(color);
+	if (!leftClick) {
+		std::cout << "Right click " << std::endl;
+		bool changed = currentColorSpace->expandToFit(color);
+		if (changed) {
+			colorSpaceWidget.setColorSpace(currentColorSpace);
+		}
+	}
+	lastClickedX = x;
+	lastClickedY = y;
+	updateThresholdedImage();
+	std::cout << std::endl;
+}
 
 void ColorCalibrate::selectColorSpace(int index) {
     currentColorSpace = &colorSpace[index];
@@ -109,7 +157,7 @@ void ColorCalibrate::selectColorSpace(int index) {
 // TODO: Ideally we'd want to have this in a separate class
 // or unify this with our regular thresholding process (maybe
 // by converting the color space parameters to a table continuously?
-void ColorCalibrate::updateThresholdedImage() {
+	void ColorCalibrate::updateThresholdedImage() {
 
     BMPYUVImage* image;
 
@@ -156,6 +204,11 @@ void ColorCalibrate::updateThresholdedImage() {
                     tempColor /= count;
                 }
             }
+			// lame hack to show a "cursor" on the thresholded image
+			// TODO do a true cursor mirroring on the thresholded image
+			if ((abs(j - lastClickedY) < BOX) && (abs(i - lastClickedX) < BOX)) {
+				tempColor = image::Color_RGB[3];
+			}
             if (tempColor) {
                 thresholdedImageLine[i] = (QRgb) tempColor;
             }
@@ -164,6 +217,7 @@ void ColorCalibrate::updateThresholdedImage() {
     //set it
     thresholdedImagePlaceholder.setPixmap(QPixmap::fromImage(thresholdedImage));
 }
+
 
 void ColorCalibrate::loadColorSpaces(QString filename) {
 

--- a/src/qtool/colorcreator/ColorCalibrate.h
+++ b/src/qtool/colorcreator/ColorCalibrate.h
@@ -18,6 +18,7 @@
 #include "viewer/ChannelImageViewer.h"
 #include "data/DataManager.h"
 #include "image/BMPYUVImage.h"
+#include "viewer/BMPImageViewerListener.h"
 //colorcreator
 #include "ColorEdit.h"
 #include "ColorTable.h"
@@ -48,6 +49,8 @@ protected slots:
     void saveColorTableBtnPushed();
     void imageTabSwitched(int);
 	void setFullColors(bool state);
+    void canvassClicked(int x, int y, int brushSize, bool leftClick);
+
 
 protected:
     void loadColorSpaces(QString filename);
@@ -61,9 +64,11 @@ private:
 
     image::BMPYUVImage* topImage;
     viewer::ChannelImageViewer topChannelImage;
+    viewer::BMPImageViewerListener* topImageViewer;
 
     image::BMPYUVImage* bottomImage;
     viewer::ChannelImageViewer bottomChannelImage;
+    viewer::BMPImageViewerListener* bottomImageViewer;
 
     ColorSpace colorSpace[image::NUM_COLORS];
     ColorSpace* currentColorSpace;
@@ -75,6 +80,7 @@ private:
     QPushButton loadSlidersBtn, saveSlidersBtn, saveColorTableBtn;
 
 	bool displayAllColors;
+	int lastClickedX, lastClickedY;
 
 };
 

--- a/src/qtool/colorcreator/ColorSpace.h
+++ b/src/qtool/colorcreator/ColorSpace.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <QObject>
+#include <QTextStream>
 #include "image/Color.h"
 #include "ClassHelper.h"
 
@@ -83,6 +84,125 @@ public:
         return true;
     }
 
+    bool verboseContains(image::Color color) const {
+		QTextStream cout(stdout);
+
+        // the circle can wrap around
+        float h = color.getH();
+        float s = color.getS();
+        float z = color.getZ();
+
+		// we sometimes get bad values of Z
+		if (z > 1.0f) {
+			z = 1.0f;
+		}
+        if (params[hMin] > params[hMax]) {
+            if (params[hMax] < h && h < params[hMin]) {
+				cout << "Failed on H " << h << " " << params[hMin] <<
+					" " << params[hMax] << endl;
+                return false;
+            }
+        } else if (params[hMax] < h || h < params[hMin]) {
+				cout << "Failed on H " << h << " " << params[hMin] <<
+					" " << params[hMax] << endl;
+            return false;
+        }
+        if (s < params[sMin] || s > params[sMax]) {
+				cout << "Failed on S " << s << " " << params[sMin] <<
+					" " << params[sMax] << endl;
+            return false;
+        }
+        if (z < params[zMin] || z > params[zMax]) {
+				cout << "Failed on Z " << z << " " << params[zMin] <<
+					" " << params[zMax] << endl;
+            return false;
+        }
+
+        float y = color.getY();
+        // add 0.5f to normalize to a 0 to 1 range
+        float v = color.getV() + 0.5f;
+        if (y < params[yMin] || y >= params[yMax]) {
+			cout << "Failed on Y " << y << " " << params[yMin] <<
+				" " << params[yMax] << endl;
+            return false;
+        }
+        if (v < params[vMin] || v >= params[vMax]) {
+			cout << "Failed on V " << v << " " << params[vMin] <<
+				" " << params[vMax] << endl;
+            return false;
+        }
+        return true;
+    }
+
+    bool expandToFit(image::Color color) {
+		QTextStream cout(stdout);
+
+        // the circle can wrap around
+        float h = color.getH();
+        float s = color.getS();
+        float z = color.getZ();
+		bool changed = false;
+
+		// we sometimes get bad values of Z
+		if (z > 1.0f) {
+			z = 1.0f;
+		}
+
+		// skip H for now as it is a bit dangerous with the wrap
+
+        if (s < params[sMin]) {
+			setParameterSilently(sMin, s);
+			changed = true;
+			cout << "Setting sMin to " << s << endl;
+		}
+		if (s > params[sMax]) {
+			setParameterSilently(sMax, s);
+			changed = true;
+			cout << "Setting sMax to " << s << endl;
+        }
+
+        if (z < params[zMin]) {
+			setParameterSilently(zMin, z);
+			changed = true;
+			cout << "Setting zMin to " << z << endl;
+		}
+		if (z > params[zMax]) {
+			setParameterSilently(zMax, z);
+			changed = true;
+			cout << "Setting zMax to " << z << endl;
+        }
+
+        float y = color.getY();
+        // add 0.5f to normalize to a 0 to 1 range
+        float v = color.getV() + 0.5f;
+        if (y < params[yMin]) {
+			setParameterSilently(yMin, y);
+			changed = true;
+			cout << "Setting yMin to " << y << endl;
+		}
+		if (y > params[yMax]) {
+			setParameterSilently(yMax, y);
+			changed = true;
+			cout << "Setting yMax to " << y << endl;
+        }
+
+        if (v < params[vMin]) {
+			setParameterSilently(vMin, v);
+			changed = true;
+			cout << "Setting vMin to " << v << endl;
+		}
+		if (v > params[vMax]) {
+			setParameterSilently(vMax, v);
+			changed = true;
+			cout << "Setting vMax to " << v << endl;
+        }
+		if (changed) {
+			emit parametersChanged();
+			return true;
+		}
+		return false;
+    }
+
     void setParameters(float* values) {
         setParametersSilently(values);
         emit parametersChanged();
@@ -95,6 +215,10 @@ public:
     void setParameter(Channel channel, float value) {
         params[channel] = value;
         emit parametersChanged();
+    }
+
+    void setParameterSilently(Channel channel, float value) {
+        params[channel] = value;
     }
 
     float getParameter(Channel channel) {

--- a/src/qtool/viewer/BMPImageViewerListener.cpp
+++ b/src/qtool/viewer/BMPImageViewerListener.cpp
@@ -39,7 +39,6 @@ void BMPImageViewerListener::wheelEvent(QWheelEvent* event) {
     if (brushSize == 0) {
         brushSize = 1;
     }
-
     updateBrushCursor();
 }
 

--- a/src/qtool/viewer/ChannelImageViewer.cpp
+++ b/src/qtool/viewer/ChannelImageViewer.cpp
@@ -9,7 +9,7 @@ using namespace man::memory;
 
 ChannelImageViewer::ChannelImageViewer(BMPYUVImage* image,
                                        QWidget *parent)
-    : BMPImageViewer(image, parent), bmpyuvimage(image) {
+    : BMPImageViewerListener(image, parent), bmpyuvimage(image) {
 
     setupUI();
 }

--- a/src/qtool/viewer/ChannelImageViewer.h
+++ b/src/qtool/viewer/ChannelImageViewer.h
@@ -10,13 +10,16 @@
 #pragma once
 
 #include <QComboBox>
+#include <QMouseEvent>
 #include "BMPImageViewer.h"
+#include "BMPImageViewerListener.h"
 #include "image/BMPYUVImage.h"
 
 namespace qtool {
 namespace viewer {
 
-class ChannelImageViewer: public BMPImageViewer {
+// inherit from BMPImageViewerListener so we can get mouse clicks
+class ChannelImageViewer: public BMPImageViewerListener {
     Q_OBJECT;
 public:
 
@@ -30,6 +33,7 @@ public:
         return BMPImageViewer::minimumSizeHint() +
                    QSize(0, channelSelect.height());
     }
+
 
 public slots:
     void selectionChanged(int i);


### PR DESCRIPTION
General improvements to the color calibration tool. Made it possible to set the sliders by right-clicking on the raw image.  Improved support for the cursor.  Shouldn't really impact anything outside of the color calibrate tool.
