### PR TITLE
Build fixes

### DIFF
--- a/src/man/CMakeLists.txt
+++ b/src/man/CMakeLists.txt
@@ -22,7 +22,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 find_package(ALCOMMON REQUIRED)
 include_directories( ${ALCOMMON_INCLUDE_DIR} )
 
-find_package(PROTOBUF REQUIRED)
+find_package( PROTOBUF REQUIRED )
+include_directories( SYSTEM ${PROTOBUF_INCLUDE_DIR} )
 
 # Configure the copy script based on our settings
 configure_file(

--- a/src/man/Makefile
+++ b/src/man/Makefile
@@ -5,8 +5,11 @@ ATOM_TOOLCHAIN = cmake/atom.cmake
 # Toolchain for building natively
 STRAIGHT_TOOLCHAIN = cmake/generic.cmake
 
-# Where the build output will be placed
-BUILD_DIR = build
+# Where the build output will be placed relative to here
+BUILD_DIR = ../../build/man
+# Here relative to the build dir
+SRC_DIR = ../../src/man
+
 # Where the files will be installed
 INSTALL_PREFIX = install/
 
@@ -36,12 +39,12 @@ install: $(BUILD_DIR)/Makefile
 
 .PHONY: cross
 cross:  $(CROSS_FILE)
-	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR); \
-	cmake  $(CMAKE_CROSS_FLAGS) ..; \
-	ccmake ..
+	cmake  $(CMAKE_CROSS_FLAGS) $(SRC_DIR); \
+	ccmake $(SRC_DIR)
 
 $(CROSS_FILE):
+	mkdir -p $(BUILD_DIR)
 	@if [ -e $(STRAIGHT_FILE) ]; then \
 		rm -r $(BUILD_DIR)/*; \
 	fi
@@ -49,12 +52,12 @@ $(CROSS_FILE):
 
 .PHONY: straight
 straight: $(STRAIGHT_FILE)
-	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR); \
-	cmake  $(CMAKE_STRAIGHT_FLAGS) ..; \
-	ccmake ..
+	cmake  $(CMAKE_STRAIGHT_FLAGS) $(SRC_DIR); \
+	ccmake $(SRC_DIR)
 
 $(STRAIGHT_FILE):
+	mkdir -p $(BUILD_DIR)
 	@if [ -e $(CROSS_FILE) ]; then \
 		rm -r $(BUILD_DIR)/*; \
 	fi

--- a/src/man/cmake/FindPROTOBUF.cmake
+++ b/src/man/cmake/FindPROTOBUF.cmake
@@ -13,7 +13,7 @@ else( OFFLINE )
   set ( PROTOBUF_LOCATION ${NBITES_DIR}/lib/protobuf_cross )
 endif( OFFLINE )
 
-set( PROTOBUF_INCLUDE_DIR ${PROTOBUF_LOCATION}/include/google )
+set( PROTOBUF_INCLUDE_DIR ${PROTOBUF_LOCATION}/include/ )
 set( PROTOBUF_LIBRARY ${PROTOBUF_LOCATION}/lib/libprotobuf.a )
 set( PROTOBUF_PROTOC_EXECUTABLE ${PROTOBUF_LOCATION}/bin/protoc )
 


### PR DESCRIPTION
Moves the build folder back to nbites/build and fixes the issue where it can't build if there's no build folder already.
