### PR TITLE
allows for splitting make process into jobs

### DIFF
--- a/src/man/Makefile
+++ b/src/man/Makefile
@@ -26,12 +26,12 @@ UPLOAD_SCRIPT = $(BUILD_DIR)/upload.sh
 
 .PHONY: build
 build: $(BUILD_DIR)/Makefile
-	make -C $(BUILD_DIR) --no-print-directory
+	$(MAKE) -C $(BUILD_DIR) --no-print-directory
 
 .PHONY: install
 install: $(BUILD_DIR)/Makefile
 	@if [ -e $(CROSS_FILE) ]; then \
-		make install -C $(BUILD_DIR) --no-print-directory; \
+		$(MAKE) INSTALL -C $(BUILD_DIR) --no-print-directory; \
 		$(UPLOAD_SCRIPT) \
 	else \
 		echo "You must build cross to install to a robot."; \


### PR DESCRIPTION
changed the `make` into the make variable `$(MAKE)` so the parent knows the child is it's own make process.
