### PR TITLE
ImageConverterModule now outportals an 8-bit ThresholdImage

### DIFF
--- a/src/man/vision/Threshold.cpp
+++ b/src/man/vision/Threshold.cpp
@@ -1713,13 +1713,11 @@ const uint16_t* Threshold::getYUV() {
 /* I haven't a clue what this method is for.
  * @param newyuv     presumably a new yuv value in bytes or something
  */
-void Threshold::setIm(const uint16_t* thrIm) {
-     thresholded = const_cast<uint8_t*>(
-		 reinterpret_cast<const uint8_t*>(thrIm));
+void Threshold::setIm(uint8_t* thrIm) {
+     thresholded = thrIm;
 }
-void Threshold::setIm_bot(const uint16_t* thrIm) {
-    thresholdedBottom = const_cast<uint8_t*>(
-        reinterpret_cast<const uint8_t*>(thrIm));
+void Threshold::setIm_bot(uint8_t* thrIm) {
+    thresholdedBottom = thrIm;
    }
 
 /* Calculate the distance between two objects (x distance only).

--- a/src/man/vision/Threshold.h
+++ b/src/man/vision/Threshold.h
@@ -177,8 +177,8 @@ public:
     int getRobotBottom(int x, int c);
     int postCheck(bool which, int left, int right);
     point <int> backStopCheck(bool which, int left, int right);
-    void setIm(const uint16_t* thrIm);
-    void setIm_bot(const uint16_t* thrIm);
+    void setIm(uint8_t* thrIm);
+    void setIm_bot(uint8_t* thrIm);
     const uint16_t* getYUV();
     static const char * getShortColor(int _id);
 

--- a/src/man/vision/Vision.cpp
+++ b/src/man/vision/Vision.cpp
@@ -73,7 +73,7 @@ Vision::Vision()
 	pose = boost::shared_ptr<NaoPose>(new NaoPose());
     thresh = new Threshold(this, pose);
     fieldLines = boost::shared_ptr<FieldLines>(new FieldLines(this, pose));
-    thresh->setIm(&global_16_image[0]);
+    thresh->setIm(&global_8_image[0]);
 }
 
 // Vision Class Deconstructor
@@ -97,7 +97,7 @@ Vision::~Vision()
 //DO NOT USE THIS FUNCTION - bende 4/3/2013
 void Vision::copyImage(const byte* image) {
     memcpy(&global_16_image[0], image, IMAGE_BYTE_SIZE);
-    thresh->setIm(&global_16_image[0]);
+    thresh->setIm(&global_8_image[0]);
 }
 
 // void Vision::notifyImage(const uint16_t* y) {
@@ -193,7 +193,7 @@ void Vision::notifyImage(const ThresholdImage& topThrIm, const PackedImage16& to
 }
 
 //DO NOT USE THIS FUNCTION - bende 4/3/2013
-void Vision::setImage(const uint16_t *image) {
+void Vision::setImage(uint8_t *image) {
     thresh->setIm(image);
 }
 

--- a/src/man/vision/Vision.h
+++ b/src/man/vision/Vision.h
@@ -95,7 +95,7 @@ public:
     // utilize the current image pointer for vision processing
 //    void notifyImage();
     // set the current image pointer to the given pointer
-    void setImage(const uint16_t* image);
+    void setImage(uint8_t* image);
 
     // visualization methods
     void drawBox(int left, int right, int bottom, int top, int c);

--- a/src/share/messages/Images.h
+++ b/src/share/messages/Images.h
@@ -278,7 +278,7 @@ class HeapPixelBuffer : public PixelBuffer
 
 protected:
   virtual ~HeapPixelBuffer() { delete [] pixels_;}
-  // effect   The destroctor just deletes the buffer
+  // effect   The destructor just deletes the buffer
 
   virtual void* address() { return pixels_;}
   // returns  The address of the first pixel
@@ -771,24 +771,24 @@ public:
 // *                     *
 // ***********************
 
-// A ThresholdImage is a packed image of unsigned 16-bit pixels. Every pixel can be one of seven colors.
+// A ThresholdImage is a packed image of unsigned 8-bit pixels. Every pixel can be one of seven colors.
 // Color segmentation is done in acquire_image_fast in src/man/image. ThresholdImage provides helper functions 
 // to identify pixels via bitwise operations.
 
-class ThresholdImage : public PackedImage16
+class ThresholdImage : public PackedImage8
 {
 public:
   ThresholdImage() {}
   // effect   Default construct null image
 
-  ThresholdImage(const PackedImage16& img) : PackedImage16(img) {}
-  // effect   Construct a copy of a PackedImage16
+  ThresholdImage(const PackedImage8& img) : PackedImage8(img) {}
+  // effect   Construct a copy of a PackedImage8
   // note     A helper function for this class, the public is not allowed to use it.
 
-  ThresholdImage(int wd, int ht) : PackedImage16(wd, ht) {}
+  ThresholdImage(int wd, int ht) : PackedImage8(wd, ht) {}
   // effect   Construct new (not yet shared) image on heap of specified size.
 
-  ThresholdImage(uint16_t* pixels, int wd, int ht, int rowPitch) : PackedImage16(pixels, wd, ht, rowPitch) {}
+  ThresholdImage(uint8_t* pixels, int wd, int ht, int rowPitch) : PackedImage8(pixels, wd, ht, rowPitch) {}
   // effect   Construct new image at specified address in memory, of specified size and pitch.
 
   bool isGreen(unsigned char threshColor) const { return threshColor & GreenBit; }


### PR DESCRIPTION
ImageConverterModule now outportals an 8-bit ThresholdImage, rather than a 16-bit image, based on Bill's suggestion.

Ben, you might want to double check the changes we made in vision. We did do some basic testing, and the logs suggested that robot was seeing things (including the ball) as it should.

ImageConverterModule only supports 1280x480 images as of now because the assembly method acquire_image_fast is not able to support any other sized image. Bill may help change the assembly method in the future, but this limitation is documented in the comments of ImageConverterModule's run_ method.
