### PR TITLE
Adds back in my tool improvements from winter break

### DIFF
--- a/src/tool/colorcreator/ColorTable.cpp
+++ b/src/tool/colorcreator/ColorTable.cpp
@@ -58,7 +58,6 @@ void ColorTable::write(string filename) {
 }
 
 int ColorTable::countColor(byte color) {
-
     int count = 0;
 
     for (int i = 0; i < TABLE_SIZE; i++) {

--- a/src/tool/colorcreator/ColorTableCreator.h
+++ b/src/tool/colorcreator/ColorTableCreator.h
@@ -78,8 +78,18 @@ protected:
     virtual void run_();
 
 private:
-    QTabWidget* imageTabs;
+    ColorTable colorTable;
+
+    QLabel* colorStats;
+    QLabel* colorTableName;
+
+    QComboBox colorSelect;
+    int currentColor;
+
     Camera::Type currentCamera;
+    std::vector<BrushStroke> brushStrokes;
+
+    QTabWidget* imageTabs;
 
     // This module contains its own diagram! Trippy.
     portals::RoboGram subdiagram;
@@ -95,13 +105,8 @@ private:
     portals::OutPortal<messages::YUVImage> bottomImage;
     portals::OutPortal<messages::YUVImage> topImage;
 
-    QLabel* colorStats;
-    QComboBox colorSelect;
-    int currentColor;
-
-    ColorTable colorTable;
-
-    std::vector<BrushStroke> brushStrokes;
+    void loadLatestTable();
+    void serializeTableName(QString latestTableName);
 };
 
 class FixedLayout: public QVBoxLayout{


### PR DESCRIPTION
1. Automatically loads (and serializes) last color table used on start up.
2. Label in color table creator displays currently loaded color table.
3. Depending on whether the user is looking at top image or bottom image in color table creator, a different color table is loaded.
