### PR TITLE
Tool supports loading multiple logs in one run

### DIFF
--- a/src/tool/Tool.cpp
+++ b/src/tool/Tool.cpp
@@ -38,6 +38,9 @@ Tool::Tool(const char* title) :
     connect(&diagram, SIGNAL(signalNewDisplayWidget(QWidget*, std::string)),
             &logView, SLOT(newDisplayWidget(QWidget*, std::string)));
 
+    connect(&diagram, SIGNAL(signalDeleteDisplayWidgets()),
+            &logView, SLOT(deleteDisplayWidgets()));
+
     connect(&diagram, SIGNAL(signalUnloggersReady()),
             this, SLOT(setUpModules()));
 

--- a/src/tool/ToolDiagram.cpp
+++ b/src/tool/ToolDiagram.cpp
@@ -40,6 +40,8 @@ ToolDiagram::ToolDiagram(QWidget* parent) : QObject(parent)
     ADD_MAPPED_TYPE(VisionRobot);
     ADD_MAPPED_TYPE(WorldModel);
     ADD_MAPPED_TYPE(YUVImage);
+
+    diagram = new portals::RoboGram; // on heap so we can delete when new log is loaded
 }
 
 bool ToolDiagram::unlogFrom(std::string path)
@@ -56,10 +58,10 @@ bool ToolDiagram::unlogFrom(std::string path)
     }
 
     unloggers.push_back(typeMap[head.name()](path));
-    diagram.addModule(*unloggers.back());
+    diagram->addModule(*unloggers.back());
 
     unlog::GUI gui = unloggers.back()->makeMyGUI();
-    diagram.addModule(*gui.module);
+    diagram->addModule(*gui.module);
     displays.push_back(gui.module);
 
     if(head.name() == "messages.YUVImage")
@@ -110,17 +112,41 @@ bool ToolDiagram::connectToUnlogger(portals::InPortal<messages::YUVImage>& input
 void ToolDiagram::runForward()
 {
     unlog::UnlogBase::readBackward = false;
-    diagram.run();
+    diagram->run();
 }
 
 void ToolDiagram::runBackward()
 {
     unlog::UnlogBase::readBackward = true;
-    diagram.run();
+    diagram->run();
 }
 
+// addUnloggers should only be called once for log folder
+// IMPORTANT whenever this is called, all old unloggers and guis are deleted
+// MUST follow the once per log folder rule for tool to behave correctly
 void ToolDiagram::addUnloggers(std::vector<std::string> paths)
 {
+    // delete the last set of unloggers
+    for (std::vector<unlog::UnlogBase*>::iterator i = unloggers.begin();
+         i != unloggers.end(); i++)
+    {
+        delete *i;
+    }
+    unloggers.clear();
+
+    // delete the last set of displays and remove all widgets
+    for (std::vector<portals::Module*>::iterator i = displays.begin();
+         i != displays.end(); i++)
+    {
+        delete *i;
+    }
+    displays.clear();
+    emit signalDeleteDisplayWidgets();
+
+    // delete old diagram, make new one
+    delete diagram;
+    diagram = new portals::RoboGram;
+
     for (std::vector<std::string>::iterator i = paths.begin();
          i != paths.end(); i++)
     {

--- a/src/tool/ToolDiagram.h
+++ b/src/tool/ToolDiagram.h
@@ -30,7 +30,7 @@ class ToolDiagram : public QObject
 public:
     ToolDiagram(QWidget *parent = 0);
 
-    void addModule(portals::Module& mod) { diagram.addModule(mod); }
+    void addModule(portals::Module& mod) { diagram->addModule(mod); }
     bool unlogFrom(std::string path);
 
     template<class T>
@@ -60,6 +60,7 @@ public:
 
 signals:
     void signalNewDisplayWidget(QWidget*, std::string);
+    void signalDeleteDisplayWidgets();
     void signalUnloggersReady();
 
 public slots:
@@ -68,7 +69,7 @@ public slots:
     void addUnloggers(std::vector<std::string> paths);
 
 protected:
-    portals::RoboGram diagram;
+    portals::RoboGram* diagram;
     std::vector<unlog::UnlogBase*> unloggers;
     std::vector<portals::Module*> displays;
 

--- a/src/tool/logview/LogViewer.cpp
+++ b/src/tool/logview/LogViewer.cpp
@@ -6,12 +6,12 @@ namespace logview {
 LogViewer::LogViewer(QWidget* parent) : QMainWindow(parent),
                                         imageTabs(this)
 {
-	QHBoxLayout* mainLayout = new QHBoxLayout;
-	QWidget* mainWidget = new QWidget;
+    QHBoxLayout* mainLayout = new QHBoxLayout;
+    QWidget* mainWidget = new QWidget;
 
-	mainLayout->addWidget(&imageTabs);
-	mainWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-	mainWidget->setLayout(mainLayout);
+    mainLayout->addWidget(&imageTabs);
+    mainWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    mainWidget->setLayout(mainLayout);
     this->setCentralWidget(mainWidget);
 
     //corner ownership
@@ -29,6 +29,7 @@ void LogViewer::newDisplayWidget(QWidget* widget, std::string title)
         dockWidget->setMaximumHeight(125);
 
         dockWidget->setWidget(widget);
+        dockWidgets.push_back(dockWidget);
         this->addDockWidget(Qt::RightDockWidgetArea, dockWidget);
     }
     else
@@ -36,6 +37,17 @@ void LogViewer::newDisplayWidget(QWidget* widget, std::string title)
         imageTabs.addTab(widget, QString(title.data()));
     }
 
+}
+
+void LogViewer::deleteDisplayWidgets()
+{
+    for (std::vector<QDockWidget*>::iterator i = dockWidgets.begin();
+         i != dockWidgets.end(); i++)
+    {
+        this->removeDockWidget(*i);
+        delete *i;
+    }
+    dockWidgets.clear();
 }
 
 }

--- a/src/tool/logview/LogViewer.h
+++ b/src/tool/logview/LogViewer.h
@@ -28,9 +28,11 @@ public:
 
 public slots:
     void newDisplayWidget(QWidget*, std::string);
+    void deleteDisplayWidgets();
 
 protected:
     QTabWidget imageTabs;
+    std::vector<QDockWidget*> dockWidgets;
 };
 
 }


### PR DESCRIPTION
Tool does not crash anymore if you try to load multiple logs without closing the tool. Widgets are closed and opened as needed.

This solution requires the following to  be true about the use of ToolDiagram::addUnloggers, or there is potential for bugs:

// addUnloggers should only be called once for log folder
// IMPORTANT whenever this is called, all old unloggers and guis are deleted
// MUST follow the once per log folder rule for tool to behave correctly
