### PR TITLE
Synced logging

### DIFF
--- a/src/man/log/LogModule.h
+++ b/src/man/log/LogModule.h
@@ -50,6 +50,9 @@ static const int ALL_PERMISSIONS = S_IRWXU | S_IRWXG | S_IRWXO;
 // for large messages that could take up a lot of memory!
 static const int DEFAULT_MAX_WRITES = 5;
 
+// Log every LOG_SYNC_HOW_OFTEN image and frame when LOG_SYNC flag is on
+static const int LOG_SYNC_HOW_OFTEN = 10;
+
 /*
  * This struct is used to hold together an aiocb (control block) and the
  * buffer it's writing from. These need to stay unchanged while the write
@@ -223,12 +226,12 @@ protected:
     {
         /* Only possible to log 1 in every 5 images, do same thing with
            all unloggers to stay synced with images */
-#ifdef LOG_EVERY_FIFTH
+#ifdef LOG_SYNC
         frameCounter++;
         // EPIC HACK: 10-second delay
         if (frameCounter < 300) return;
         // EPIC HACK: don't try to log every frame
-        if (frameCounter%5 != 0) return;
+        if (frameCounter%LOG_SYNC_HOW_OFTEN != 0) return;
 #endif
 
         input.latch();
@@ -254,7 +257,7 @@ protected:
 
     portals::InPortal<T> input;
     std::list<Write> ongoing;
-#ifdef LOG_EVERY_FIFTH
+#ifdef LOG_SYNC
     int frameCounter;
 #endif
 };
@@ -391,7 +394,11 @@ protected:
         if (frameCounter < 300) return;
 
         // EPIC HACK: don't try to log every image
+#ifdef LOG_SYNC
+        if (frameCounter%LOG_SYNC_HOW_OFTEN != 0) return;
+#else
         if (frameCounter%5 != 0) return;
+#endif
 
         input.latch();
 

--- a/src/share/cmake/DebugConfig.cmake
+++ b/src/share/cmake/DebugConfig.cmake
@@ -109,8 +109,8 @@ if(USE_LOGGING)
     OFF
     )
   option(
-    LOG_EVERY_FIFTH
-    "Enable to log every fifth frame in order to stay synced with image logging"
+    LOG_SYNC
+    "Enable to log every tenth frame in order to stay synced with image logging"
     ON
     )
 
@@ -124,7 +124,7 @@ else(USE_LOGGING)
   unset(LOG_LOCALIZATION CACHE)
   unset(LOG_OBSERVATIONS CACHE)
   unset(LOG_ODOMETRY CACHE)
-  unset(LOG_EVERY_FIFTH CACHE)
+  unset(LOG_SYNC CACHE)
 endif(USE_LOGGING)
 
 endif( NOT OFFLINE )

--- a/src/share/cmake/DebugConfig.in
+++ b/src/share/cmake/DebugConfig.in
@@ -130,9 +130,9 @@
 #   undef LOG_ODOMETRY
 #endif
 
-#define LOG_EVERY_FIFTH_${LOG_EVERY_FIFTH}
-#ifdef  LOG_EVERY_FIFTH_ON
-#   define LOG_EVERY_FIFTH
+#define LOG_SYNC_${LOG_SYNC}
+#ifdef  LOG_SYNC_ON
+#   define LOG_SYNC
 #else
-#   undef LOG_EVERY_FIFTH
+#   undef LOG_SYNC
 #endif


### PR DESCRIPTION
- Run method runs 1 in 5 times for all loggers, not just image loggers
- Passes joint angles and inertial states thru vision to sync them up with images
- Provides a cmake option to turn on and off 1 in 5 time logging (for everything but images), defaults to on
