### PR TITLE
Corrects IP addresses for changes to Robotics AP

### DIFF
--- a/src/man/support/CommDef.h
+++ b/src/man/support/CommDef.h
@@ -36,15 +36,15 @@ typedef struct robot_ip_pair_t
 }robot_ip_pair;
 
 // Bowdoin IPs.
-static const robot_ip_pair wash    = {"wash"   , "139.140.218.9" };
-static const robot_ip_pair river   = {"river"  , "139.140.218.10"};
-static const robot_ip_pair jayne   = {"jayne"  , "139.140.218.11"};
-static const robot_ip_pair simon   = {"simon"  , "139.140.218.12"};
-static const robot_ip_pair inara   = {"inara"  , "139.140.218.13"};
-static const robot_ip_pair kaylee  = {"kaylee" , "139.140.218.14"};
-static const robot_ip_pair vera    = {"vera"   , "139.140.218.15"};
-static const robot_ip_pair mal     = {"mal"    , "139.140.218.16"};
-static const robot_ip_pair zoe     = {"zoe"    , "139.140.218.17"};
+static const robot_ip_pair wash    = {"wash"   , "139.140.192.9" };
+static const robot_ip_pair river   = {"river"  , "139.140.192.10"};
+static const robot_ip_pair jayne   = {"jayne"  , "139.140.192.11"};
+static const robot_ip_pair simon   = {"simon"  , "139.140.192.12"};
+static const robot_ip_pair inara   = {"inara"  , "139.140.192.13"};
+static const robot_ip_pair kaylee  = {"kaylee" , "139.140.192.14"};
+static const robot_ip_pair vera    = {"vera"   , "139.140.192.15"};
+static const robot_ip_pair mal     = {"mal"    , "139.140.192.16"};
+static const robot_ip_pair zoe     = {"zoe"    , "139.140.192.17"};
 
 static const robot_ip_pair robotIPs[NUM_ROBOTS] = {wash, river, jayne,
                                                    simon, inara, kaylee,


### PR DESCRIPTION
IP address block changed last semester. 218 -> 192.

On a side note, the mac addresses of the some of the robots were out of date, but IT has now corrected this. Networking issues in the lab should be resolved now.
