### PR TITLE
Fix for copy-files.sh scp failure to nao.local

### DIFF
--- a/util/scripts/copy-files.sh
+++ b/util/scripts/copy-files.sh
@@ -18,6 +18,10 @@ read SERVER_UNAME
 
 rsync -vr $SERVER_UNAME@$ROBOCUP/$FOLDER .
 
+# Must remove previous known_host for nao.local otherwise scp 
+# will fail with alert that SOMEONE IS DOING SOMETHING NASTY
+ssh-keygen -f "/home/$(whoami)/.ssh/known_hosts" -R nao.local
+
 # Copy important libraries to home folder
 echo "Copying necessary files TO THE ROBOT!"
 scp -r $FOLDER setup-robot.sh $ROBOT_UNAME@$ROBOT:


### PR DESCRIPTION
Fixed scp failing when copying files to a newly flashed robot due to "nao.local" already being in known_hosts but with a different ssh fingerprint. (This is the "IT IS POSSIBLE SOMEBODY IS DOING SOMETHING NASTY" bug).
