### PR TITLE
Adds flip button and moves robot states box up in worldview tool.

### DIFF
--- a/src/tool/worldview/WorldView.cpp
+++ b/src/tool/worldview/WorldView.cpp
@@ -37,6 +37,8 @@ WorldView::WorldView(QWidget* parent)
     QVBoxLayout *options = new QVBoxLayout();
     options->setAlignment(Qt::AlignTop);
     startButton = new QPushButton(QString("Start World Viewer"));
+    flipButton = new QPushButton(QString("FLIP"));
+    options->addWidget(flipButton);
     options->addWidget(startButton);
 
     QHBoxLayout *teamLayout = new QHBoxLayout();
@@ -51,7 +53,7 @@ WorldView::WorldView(QWidget* parent)
     connect(teamSelector, SIGNAL(editingFinished()), this, SLOT(teamChanged()));
 
     QVBoxLayout *stateLayout = new QVBoxLayout();
-    stateLayout->setAlignment(Qt::AlignBottom);
+    stateLayout->setAlignment(Qt::AlignTop);
 
     QGroupBox *stateBox = new QGroupBox(tr("Robot States"));
     QVBoxLayout *boxLayout = new QVBoxLayout();
@@ -106,6 +108,7 @@ WorldView::WorldView(QWidget* parent)
     this->setLayout(mainLayout);
 
     connect(startButton, SIGNAL(clicked()), this, SLOT(startButtonClicked()));
+    connect(flipButton, SIGNAL(clicked()), this, SLOT(flipButtonClicked()));
 
     for (int i = 0; i < NUM_PLAYERS_PER_TEAM; ++i)
     {
@@ -138,6 +141,13 @@ void WorldView::run_()
     sharedIn.latch();
     fieldPainter->updateWithSharedBallMessage(sharedIn.message());
 
+    mutex.unlock();
+}
+
+void WorldView::flipButtonClicked()
+{
+    mutex.lock();
+    fieldPainter->flipScreen();
     mutex.unlock();
 }
 

--- a/src/tool/worldview/WorldView.h
+++ b/src/tool/worldview/WorldView.h
@@ -35,6 +35,7 @@ protected:
     WorldViewPainter* fieldPainter;
 
     QPushButton* startButton;
+    QPushButton* flipButton;
 
     QLineEdit* teamSelector;
 
@@ -48,6 +49,7 @@ protected:
     QMutex mutex;
 
 protected slots:
+    void flipButtonClicked();
     void startButtonClicked();
     void stopButtonClicked();
     void teamChanged();

--- a/src/tool/worldview/WorldViewPainter.cpp
+++ b/src/tool/worldview/WorldViewPainter.cpp
@@ -14,6 +14,7 @@ static const int VISION_DISTANCE = 50;
 WorldViewPainter::WorldViewPainter(QWidget* parent, float scaleFactor_) :
     PaintField(parent, scaleFactor_)
 {
+    flipped = 0;
 }
 
 void WorldViewPainter::paintEvent(QPaintEvent* event)
@@ -26,29 +27,34 @@ void WorldViewPainter::paintEvent(QPaintEvent* event)
         paintRobotLocation(event, curLoc[i], QString::number(i+1));
     }
 
-        paintSharedBallLocation(event, sharedballLoc);
+    paintSharedBallLocation(event, sharedballLoc);
 }
 
 void WorldViewPainter::paintSharedBallLocation(QPaintEvent* event,
                                                messages::SharedBall msg)
 {
-
     if (msg.ball_on()) {
-         QPainter painter(this);
-         painter.translate(0, FIELD_GREEN_HEIGHT);
-         painter.scale(1, -1);
-         QPoint ballCenter(msg.x(),
-                           msg.y());
+        QPainter painter(this);
+        if (flipped)
+        {
+            painter.translate(FIELD_GREEN_WIDTH*scaleFactor, 0);
+            painter.scale(-scaleFactor, scaleFactor);
+        }
+        else
+        {
+            painter.translate(0, FIELD_GREEN_HEIGHT*scaleFactor);
+            painter.scale(scaleFactor, -scaleFactor);
+        }
+        QPoint ballCenter(msg.x(),
+                          msg.y());
 
-         //draw the weighted averaged location of the ball
-         painter.setBrush(QColor::fromRgb(153,0,153));
-         painter.drawEllipse(ballCenter,
-                             8,
-                             8);
+        //draw the weighted averaged location of the ball
+        painter.setBrush(QColor::fromRgb(153,0,153));
+        painter.drawEllipse(ballCenter,
+                            8,
+                            8);
     }
-
     return;
-
 }
 
 void WorldViewPainter::paintRobotLocation(QPaintEvent* event,
@@ -61,8 +67,16 @@ void WorldViewPainter::paintRobotLocation(QPaintEvent* event,
     }
 
     QPainter painter(this);
-    painter.translate(0, FIELD_GREEN_HEIGHT*scaleFactor);
-    painter.scale(scaleFactor, -scaleFactor);
+    if (flipped)
+    {
+        painter.translate(FIELD_GREEN_WIDTH*scaleFactor, 0);
+        painter.scale(-scaleFactor, scaleFactor);
+    }
+    else
+    {
+        painter.translate(0, FIELD_GREEN_HEIGHT*scaleFactor);
+        painter.scale(scaleFactor, -scaleFactor);
+    }
 
     Qt::GlobalColor brushColor = Qt::cyan;
     if (msg.fallen())
@@ -158,10 +172,21 @@ void WorldViewPainter::updateWithLocationMessage(messages::WorldModel newLoc,
     update();
 }
 
-void WorldViewPainter::updateWithSharedBallMessage(messages::SharedBall sharedLoc) {
+void WorldViewPainter::updateWithSharedBallMessage(messages::SharedBall sharedLoc)
+{
     sharedballLoc = sharedLoc;
     update();
+}
 
+void WorldViewPainter::flipScreen()
+{
+    if (flipped) {
+        flipped = 0;
+    }
+    else {
+        flipped = 1;
+    }
+    update();
 }
 
 } // namespace worldview

--- a/src/tool/worldview/WorldViewPainter.h
+++ b/src/tool/worldview/WorldViewPainter.h
@@ -39,6 +39,7 @@ public:
 
     void updateWithLocationMessage(messages::WorldModel newLoc, int index);
     void updateWithSharedBallMessage(messages::SharedBall sharedLoc);
+    void flipScreen();
 
 protected:
     // Paint the field
@@ -54,6 +55,8 @@ protected:
 private:
     messages::WorldModel curLoc[NUM_PLAYERS_PER_TEAM];
     messages::SharedBall sharedballLoc;
+
+    int flipped;
 
 };
 


### PR DESCRIPTION
Adds in worldview:
- A "FLIP BUTTON" that swaps which team is on which side of the field
- Moves the "ROBOT STATES" box up so it is not cut off on the bottom
