### PR TITLE
Fixes edge-case where players will not switch to role 5

### DIFF
--- a/src/man/behaviors/players/PenaltyStates.py
+++ b/src/man/behaviors/players/PenaltyStates.py
@@ -137,7 +137,7 @@ def determineRole(player):
 
     position = 0
 
-    for i in range(3):
+    for i in range(4):
         if openSpaces[i] and roleConstants.canRoleSwitchTo(i+2):
             roleConstants.setRoleConstants(player, i+2)
             return player.goLater(player.gameState)

--- a/src/man/behaviors/players/pBrunswick.py
+++ b/src/man/behaviors/players/pBrunswick.py
@@ -60,7 +60,7 @@ class SoccerPlayer(SoccerFSA.SoccerFSA):
         # Controls whether we do a motion kick
         self.motionKick = False
         # Controls whether we will role switch
-        self.roleSwitching = False
+        self.roleSwitching = True
         # Controls whether we use claims
         self.useClaims = True
         self.returningFromPenalty = False


### PR DESCRIPTION
Previously determineRole did not check to see if role 5 was open, so it chose the highest-numbered role available. (so if you penalize two chasers, the second chaser would end up coming back in as role 3)

Also turns roleswitching back on.
