### PR TITLE
remove an ifndef that prevented the azimuth being set to homography offline

### DIFF
--- a/src/man/vision/VisionModule.cpp
+++ b/src/man/vision/VisionModule.cpp
@@ -228,9 +228,8 @@ void VisionModule::run_()
             homography[i]->roll(calibrationParams[i]->getRoll());
 
             homography[i]->tilt(kinematics[i]->tilt() + calibrationParams[i]->getTilt() + azOffset);
-#ifndef OFFLINE
+
             homography[i]->azimuth(kinematics[i]->azimuth());
-#endif
         }
 
         times[i][1] = timer.end();


### PR DESCRIPTION
Removing the ifndef because otherwise when using nbtool the azimuth in homography is always zero.
