### PR TITLE
double free crash solved. when we return false in alloc everything re…

### DIFF
--- a/src/man/vision/Spots.cpp
+++ b/src/man/vision/Spots.cpp
@@ -43,9 +43,6 @@ SpotDetector::~SpotDetector()
 bool SpotDetector::alloc(const ImageLiteBase& src)
 {
   if(!src.hasProperDimensions()) {
-    delete[] innerColumns;
-    delete[] outerColumns;
-    delete[] filteredImageMemory;
     _spots.clear();
     return false;
   }


### PR DESCRIPTION
…turns false and destructor is automatically called. so no need to delete anything manually. #732 