### PR TITLE
Change URLs in CMake files from Google Code to Github

### DIFF
--- a/src/share/cmake/BuildGTest.cmake
+++ b/src/share/cmake/BuildGTest.cmake
@@ -3,7 +3,7 @@
 # Only update gtest if the user is missing it.
 # Make three processes because apparently commands are NOT executed sequentially.
 if( NOT EXISTS ${NBITES_DIR}/lib/gtest-1.6.0 )
-  execute_process( COMMAND wget http://googletest.googlecode.com/files/gtest-1.6.0.zip
+  execute_process( COMMAND wget https://github.com/google/googletest/archive/release-1.6.0.tar.gz
     WORKING_DIRECTORY ${NBITES_DIR}/lib
     )
   execute_process( COMMAND unzip -q gtest-1.6.0.zip

--- a/src/share/cmake/BuildProtobuf.cmake
+++ b/src/share/cmake/BuildProtobuf.cmake
@@ -11,7 +11,7 @@ endif( OFFLINE )
 # http://stackoverflow.com/questions/9689183/cmake-googletest
 ExternalProject_Add(
     protobuf_libs
-    URL http://protobuf.googlecode.com/files/protobuf-2.4.1.tar.gz
+    URL https://github.com/google/protobuf/releases/download/v2.4.1/protobuf-2.4.1.tar.gz
     SOURCE_DIR ${CMAKE_BINARY_DIR}/protobufsrc
     CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/protobufsrc/configure -prefix=${PROTO_INSTALL} --with-pic
     INSTALL_DIR ${PROTO_INSTALL}


### PR DESCRIPTION
Google Code stopped hosting tarball archives for many of its projects. Our makefiles were failing when we tried to install protobufs because the protobufs were no longer stored at the Google Code URL we were wget-ing. I updated the Google Code URLs to Github URLs, where the projects are now being stored.
